### PR TITLE
Resolve #11: [task]修复github-task-handler在issue加入了ai-doing label后，仍然继续处理的问题

### DIFF
--- a/.trae/skills/github-task-handler/index.js
+++ b/.trae/skills/github-task-handler/index.js
@@ -307,6 +307,10 @@ async function fetchTasks(options = {}) {
       continue;
     }
 
+    if (issue.labels && issue.labels.some(label => label.name === 'ai-doing')) {
+      continue;
+    }
+
     const author = issue.user.login;
     const isAdmin = adminUsers.has(author) || await checkUserPermission(owner, repo, author);
 


### PR DESCRIPTION
## Summary

This PR resolves issue #11

## Original Issue

Fetches GitHub issues from project repo, filters by admin authors adn [task] prefix and no ai-doing label

## Changes

- Implemented the requested feature/fix

Closes #11